### PR TITLE
Always assign the "front face" identity of a collection proxy to the proxiedObject when faulting in after a refresh

### DIFF
--- a/SSW ReStore Main/SSWDBObjectProxy.class.st
+++ b/SSW ReStore Main/SSWDBObjectProxy.class.st
@@ -526,10 +526,12 @@ SSWDBObjectProxy >> _unstore [
 
 { #category : #'actions-internal' }
 SSWDBObjectProxy >> _updateCollectionProxyUsing: aCollectionSpec [
+	"Assign the correct collection proxy for <aCollectionSpec> to the proxied object. Return the collection proxy.
+	Note that we may actually assign the proxied collection itself, if the collection proxy is swapped--what is important
+	is that we assign the correct *identity* so everything works out."
 
-	"Return the collection proxy"
-
-	^aCollectionSpec accessor value: (collectionProxies at: aCollectionSpec) in: proxiedObject
+	^aCollectionSpec accessor value: (collectionProxies at: aCollectionSpec) _frontFace
+		in: proxiedObject.
 ]
 
 { #category : #accessing }

--- a/SSW ReStore Main/SSWDBProxy.class.st
+++ b/SSW ReStore Main/SSWDBProxy.class.st
@@ -254,6 +254,16 @@ SSWDBProxy >> _forgetProxiedObject [
 	proxiedObject := nil
 ]
 
+{ #category : #accessing }
+SSWDBProxy >> _frontFace [
+	"Private - Answer the 'front face' identity associated with the receiver--the identity that should be referenced by other persisted objects.
+	When the receiver is swapped, this is the proxiedObject.
+	
+	N.B. Must be called in a critical section."
+
+	^self _isSwapped ifTrue: [self _proxiedObject] ifFalse: [self].
+]
+
 { #category : #testing }
 SSWDBProxy >> _hasChanged [
 

--- a/SSW ReStore Tests/SSWReStoreRefreshTest.class.st
+++ b/SSW ReStore Tests/SSWReStoreRefreshTest.class.st
@@ -673,6 +673,29 @@ SSWReStoreRefreshTest >> testRefreshWithOnRollback [
 			removeSelector: #onRollback fromClass: OwnerTest]
 ]
 
+{ #category : #'unit tests' }
+SSWReStoreRefreshTest >> testSwapCollectionProxyBeforeFaultInParentAfterRefresh [
+	| owner coll |
+	owner := (OwnerTest storedInstancesIn: reStore) first.
+	coll := owner ownedOrdered.
+	"Sanity checks:"
+	self deny: owner isDBProxy.
+	self assert: coll isDBProxy.
+	"Must be a lazy refresh as a force refresh will link everything up before any proxies can be swapped"
+	reStore lazyRefresh: owner.
+	self assert: owner isDBProxy.
+	self deny: owner _isRecovered.
+	"Swap the collection proxy before triggering fault-in of the owner. In practice this can happen due to process contention, where the collection is on the stack of another process, rather than someone explicitly holding a reference to the collection."
+	coll first.
+	self deny: coll isDBProxy.
+	self assert: owner isDBProxy.
+	self deny: owner _isRecovered.
+	"Now trigger fault-in of the owner. If the 'back face' identity is mistakenly assigned this will fail"
+	self assert: coll identicalTo: owner ownedOrdered.
+	"Or, more practically, we should not get a 'Trying to swap already-swapped proxy' error here:"
+	self shouldnt: [owner ownedOrdered first] raise: Error.
+]
+
 { #category : #running }
 SSWReStoreRefreshTest >> usesVersioning [
 


### PR DESCRIPTION
Analogous to [ReStore#1](https://github.com/rko281/ReStore/pull/1).