### PR TITLE
A couple minor fixes to query logging

### DIFF
--- a/SSW ReStore for Pharo/SSWReStoreDBConnection.trait.st
+++ b/SSW ReStore for Pharo/SSWReStoreDBConnection.trait.st
@@ -233,7 +233,7 @@ SSWReStoreDBConnection >> isDebug [
 { #category : #querying }
 SSWReStoreDBConnection >> logQueryExecution: aString [
 
-	self debugStream ifNotNil: [ :stream | stream cr; show: aString].
+	self debugStream ifNotNil: [ :stream | stream cr; nextPutAll: aString].
 	self incrementQueryCount
 ]
 

--- a/SSW ReStore for Pharo/SSWReStoreDBConnection.trait.st
+++ b/SSW ReStore for Pharo/SSWReStoreDBConnection.trait.st
@@ -233,7 +233,7 @@ SSWReStoreDBConnection >> isDebug [
 { #category : #querying }
 SSWReStoreDBConnection >> logQueryExecution: aString [
 
-	self debugStream ifNotNil: [ :stream | stream cr; nextPutAll: aString].
+	self debugStream ifNotNil: [ :stream | stream nextPutAll: aString; nextPut: $;; cr].
 	self incrementQueryCount
 ]
 


### PR DESCRIPTION
`#show:` is only understood by the Transcript—no reason not to use `#nextPutAll:` which is understood everywhere. And, in Dolphin, each query is logged with a trailing semicolon and newline, rather than a leading newline and no semicolon—nice to keep these consistent.