### PR TITLE
Fix case of broken change detection for mutable fields (e.g. Bitmask) 

### DIFF
--- a/SSW ReStore Tables/Object.extension.st
+++ b/SSW ReStore Tables/Object.extension.st
@@ -69,6 +69,16 @@ Object class >> persistencyRootClass [
 ]
 
 { #category : #'*SSW ReStore Tables' }
+Object >> related [
+
+	"Return a related version of the receiver"
+
+	^SSWDBRelatedWrapper on: self
+
+
+]
+
+{ #category : #'*SSW ReStore Tables' }
 Object class >> reStoreDefinition [
 
 	"Return anSSWDBClassDefinition setting out the details of how the receiver is to be persisted.
@@ -148,16 +158,6 @@ Object class >> reStoreValueClass [
 	^self isPersistentBaseClass
 		ifTrue: [self] "Usually"
 		ifFalse: [self reStoreIDClass]
-]
-
-{ #category : #'*SSW ReStore Tables' }
-Object >> related [
-
-	"Return a related version of the receiver"
-
-	^SSWDBRelatedWrapper on: self
-
-
 ]
 
 { #category : #'*SSW ReStore Tables' }

--- a/SSW ReStore Tables/SSWDBAbstractSubTable.class.st
+++ b/SSW ReStore Tables/SSWDBAbstractSubTable.class.st
@@ -68,16 +68,6 @@ SSWDBAbstractSubTable >> isRootTable [
 	^false
 ]
 
-{ #category : #'instance creation' }
-SSWDBAbstractSubTable >> recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy [
-	
-	"Set the class of the proxy to the actual class of object, since this may be one of the receiver's instanceClass' subclasses"
-	
-	super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy.
-	
-	anSSWDBObjectProxy _class: anSSWDBObjectProxy _proxiedObject class
-]
-
 { #category : #evaluating }
 SSWDBAbstractSubTable >> registerClass [
 

--- a/SSW ReStore Tables/SSWDBInheritedTable.class.st
+++ b/SSW ReStore Tables/SSWDBInheritedTable.class.st
@@ -61,6 +61,34 @@ SSWDBInheritedTable >> instanceClassFromRow: aDBRow [
 	^self classField convertValue: (aDBRow lookupField: self classField)
 ]
 
+{ #category : #private }
+SSWDBInheritedTable >> recoverExactClassInstanceFromRow: aDBRow into: anSSWDBObjectProxy [
+	"Private - Recover assuming that aDBRow represents an object of exactly our instanceClass.
+	Class has already been set on the proxy (see #recoverInstanceFromRow:into:"
+
+	super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy.
+]
+
+{ #category : #'instance creation' }
+SSWDBInheritedTable >> recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy [
+	"Redirect to the relevant concrete class, ensuring the proxy is informed of the actual class of the object.
+	We must do this before setting the proxiedObject to ensure that the correct list of fields is used when
+	initializing the copyObject.
+
+	N.B. This should always be our instanceClass or a subclass thereof, never higher in the hierarchy.
+	For leaf tables this means it should always be exactly our instanceClass, but this shared implementation is simpler."
+
+	| class |
+	class := self instanceClassFromRow: aDBRow.
+	self assert: (class includesBehavior: self instanceClass)
+		description: 
+			['Proxy for ' , self instanceClass name , ' retrieved a ' , class name , ' from the database.'].
+	anSSWDBObjectProxy _class: class.
+	(class = self instanceClass ifTrue: [self] ifFalse: [self reStore tableForClass: class])
+		recoverExactClassInstanceFromRow: aDBRow
+		into: anSSWDBObjectProxy.
+]
+
 { #category : #defining }
 SSWDBInheritedTable >> setDefaultClassField [
 	

--- a/SSW ReStore Tables/SSWDBIntermediateTable.class.st
+++ b/SSW ReStore Tables/SSWDBIntermediateTable.class.st
@@ -24,20 +24,6 @@ SSWDBIntermediateTable >> _classCondition [
 	^conditions
 ]
 
-{ #category : #'instance creation' }
-SSWDBIntermediateTable >> recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy [
-	
-	"Redirect to the relevant concrete class"
-	
-	| class |
-	
-	class := self instanceClassFromRow: aDBRow.
-
-	class = self instanceClass
-		ifTrue: [super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy]
-		ifFalse: [(self reStore tableForClass: class) recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy]
-]
-
 { #category : #evaluating }
 SSWDBIntermediateTable >> subclasses [
 

--- a/SSW ReStore Tables/SSWDBSuperTable.class.st
+++ b/SSW ReStore Tables/SSWDBSuperTable.class.st
@@ -49,24 +49,6 @@ SSWDBSuperTable >> forCreation [
 ]
 
 { #category : #'instance creation' }
-SSWDBSuperTable >> recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy [
-	
-	"Redirect to the relevant concrete class. Also set the class of the proxy to the actual class of object.
-	(since this may be one of the receiver's instanceClass' subclasses)"
-	
-	| class |
-	
-	class := self instanceClassFromRow: aDBRow.
-
-	class = self instanceClass
-		ifTrue: [super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy]
-		ifFalse: [(self reStore tableForClass: class) 
-				recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy].
-	
-	anSSWDBObjectProxy _class: anSSWDBObjectProxy _proxiedObject class
-]
-
-{ #category : #'instance creation' }
 SSWDBSuperTable >> refreshProxy: aProxy whereChangedFromRow: aDBRow [
 
 	"Redirect to the relevant concrete class"

--- a/SSW ReStore Tests/MidPerson.class.st
+++ b/SSW ReStore Tests/MidPerson.class.st
@@ -8,18 +8,35 @@ Class {
 	#superclass : #SuperPerson,
 	#instVars : [
 		'middleName',
+		'midFlags',
 		'midFriend'
 	],
 	#category : #'SSW ReStore Tests'
 }
 
+{ #category : #constants }
+MidPerson class >> mutableAspects [
+	^super mutableAspects copyWith: #midFlags.
+]
+
 { #category : #public }
 MidPerson class >> reStoreDefinition [
-
 	^super reStoreDefinition
 		define: #middleName as: (String maxSize: 128);
 		define: #midFriend as: SuperPerson;
-		yourself
+		define: #midFlags as: TestBitmask;
+		yourself.
+]
+
+{ #category : #initializing }
+MidPerson >> initialize [
+	super initialize.
+	midFlags := TestBitmask new.
+]
+
+{ #category : #accessing }
+MidPerson >> midFlags [
+	^midFlags.
 ]
 
 { #category : #accessing }

--- a/SSW ReStore Tests/SSWReStoreHierarchyTest.class.st
+++ b/SSW ReStore Tests/SSWReStoreHierarchyTest.class.st
@@ -11,10 +11,11 @@ Class {
 
 { #category : #'unit tests' }
 SSWReStoreHierarchyTest >> _testClassOfProxyOfIndirectInstanceOf: aClass [
+	"Verify that, even when recovered via a second path, and without specifying the class as part of the retrieval,
+	the class of the proxy of an object from a persistent hierarchy is set correctly (previously not the case for leaf classes)"
 
-	"Verify that, even when recovered via a second path, the class of the proxy of an object from a persistent hierarchy is set correctly (previously not the case for leaf classes)"
-
-	self _testClassOfProxyOfInstanceOf: aClass recoveredBy: [ :proxy | (reStore instancesOf: aClass) asOrderedCollection collect: [ :each | each firstName]]
+	self _testClassOfProxyOfInstanceOf: aClass
+		recoveredBy: [:proxy | (reStore instancesOf: SuperPerson) asOrderedCollection collect: [:each | each firstName]].
 ]
 
 { #category : #'unit tests' }
@@ -25,29 +26,41 @@ SSWReStoreHierarchyTest >> _testClassOfProxyOfInstanceOf: aClass [
 
 { #category : #'unit tests' }
 SSWReStoreHierarchyTest >> _testClassOfProxyOfInstanceOf: aClass recoveredBy: aBlock [
+	"Verify that, when recovered using aBlock after initially being an unrecovered proxy,
+	the class of the proxy of an object from a persistent hierarchy is set correctly.
+	Also verify that any mutable fields have been correctly copied and change-detection functions correctly."
 
-	"Verify that, when recovered using aBlock after initially being an unrecovered proxy, the class of the proxy of an object from a persistent hierarchy is set correctly"
-
-	| owner |
-
+	| owner proxy |
 	"Just using MidPerson here for its reference to SuperPerson in its midFriend inst var"
 	owner := MidPerson new firstName: 'owner'.
-	owner midFriend: ((aClass storedInstancesIn: reStore) first).
+	owner midFriend: (aClass storedInstancesIn: reStore) first.
 	owner storeIn: reStore.
-
 	reStore simulateReconnect.
 
 	"Read the owner; at this stage midFriend will just be an unrecovered proxy"
-	owner := (MidPerson storedInstancesIn: reStore) detect: [ :each | each firstName = 'owner'].
+	owner := (MidPerson storedInstancesIn: reStore) detect: [:each | each firstName = 'owner'].
 	self assert: owner midFriend isDBProxy.
 	self assert: owner midFriend _proxiedObject isNil.
-	self assert: owner midFriend _class equals: SuperPerson. "at this stage - proxied object has not been read"
+	self assert: owner midFriend _class equals: SuperPerson.	"at this stage - proxied object has not been read"
 
 	"Recover it"
 	aBlock value: owner midFriend.
 	self deny: owner midFriend isDBProxy.
 	self assert: owner midFriend class equals: aClass.
-	self assert: (owner midFriend _dbProxyIn: reStore) _class equals: aClass
+	proxy := owner midFriend _dbProxyIn: reStore.
+	self assert: proxy _class equals: aClass.
+
+	"Check that all declared mutable properties have been properly copied"
+	aClass mutableAspects withIndexDo: 
+			[:sym :i |
+			self deny: (proxy _proxiedObject perform: sym) == (proxy _copyObject perform: sym).
+			self deny: ((owner midFriend perform: sym) isBitSet: i).	"Sanity check, bitmask initializes with 0"
+			(owner midFriend perform: sym) bitSet: i].
+	owner midFriend storeIn: reStore.
+	reStore simulateReconnect.
+	owner := (MidPerson storedInstancesIn: reStore) detect: [:each | each firstName = 'owner'].
+	aClass mutableAspects
+		withIndexDo: [:sym :i | self assert: ((owner midFriend perform: sym) isBitSet: i)].
 ]
 
 { #category : #running }
@@ -199,31 +212,6 @@ SSWReStoreHierarchyTest >> testClassOfProxyOfIndirectSuperInstance [
 ]
 
 { #category : #'unit tests' }
-SSWReStoreHierarchyTest >> testClassOfProxyOfInstanceOf: aClass [
-
-	| owner |
-
-	"Just using MidPerson here for its reference to SuperPerson in its midFriend inst var"
-	owner := MidPerson new firstName: 'owner'.
-	owner midFriend: ((aClass storedInstancesIn: reStore) first).
-	owner storeIn: reStore.
-
-	reStore simulateReconnect.
-
-	"Read the owner; at this stage midFriend will just be an unrecovered proxy"
-	owner := (MidPerson storedInstancesIn: reStore) detect: [ :each | each firstName = 'owner'].
-	self assert: owner midFriend isDBProxy.
-	self assert: owner midFriend _proxiedObject isNil.
-	self assert: owner midFriend _class equals: SuperPerson. "at this stage - proxied object has not been read"
-
-	"Read via its own class"
-	(reStore instancesOf: aClass) asOrderedCollection collect: [ :each | each firstName].
-	self deny: owner midFriend isDBProxy.
-	self assert: owner midFriend class equals: aClass.
-	self assert: (owner midFriend _dbProxyIn: reStore) _class equals: aClass
-]
-
-{ #category : #'unit tests' }
 SSWReStoreHierarchyTest >> testClassOfProxyOfMidInstance [
 
 	self _testClassOfProxyOfInstanceOf: MidPerson
@@ -341,4 +329,16 @@ SSWReStoreHierarchyTest >> testInheritanceStructureWithoutIntermediateInheritanc
 			removeKey: #shouldSubclassesInheritPersistency;
 			removeKey: #addClassDefinitionTo:.
 		AbstractB class flushMethodCache]
+]
+
+{ #category : #'unit tests' }
+SSWReStoreHierarchyTest >> testRetrievingIncompatibleClassRaisesError [
+	| detailedID midID |
+	midID := (reStore instancesOf: MidPerson) first _id.
+	detailedID := (DetailedPerson1 new storeIn: reStore) _id.
+	reStore simulateReconnect.
+	"Attempt to retrieve what is actually a DetailedPerson as if it were a MidPerson (siblings)"
+	self should: [(reStore deferredObjectOfClass: MidPerson withID: detailedID) firstName] raise: Error.
+	"As above, but parent of the declared class"
+	self should: [(reStore deferredObjectOfClass: SubPerson withID: midID) firstName] raise: Error.
 ]

--- a/SSW ReStore Tests/SubPerson.class.st
+++ b/SSW ReStore Tests/SubPerson.class.st
@@ -7,17 +7,23 @@ Class {
 	#name : #SubPerson,
 	#superclass : #MidPerson,
 	#instVars : [
-		'age'
+		'age',
+		'subFlags'
 	],
 	#category : #'SSW ReStore Tests'
 }
 
+{ #category : #constants }
+SubPerson class >> mutableAspects [
+	^super mutableAspects copyWith: #subFlags.
+]
+
 { #category : #public }
 SubPerson class >> reStoreDefinition [
-
 	^super reStoreDefinition
 		define: #age as: Integer;
-		yourself
+		define: #subFlags as: TestBitmask;
+		yourself.
 ]
 
 { #category : #accessing }
@@ -28,4 +34,15 @@ SubPerson >> age [
 { #category : #accessing }
 SubPerson >> age: anObject [
 	age := anObject
+]
+
+{ #category : #initializing }
+SubPerson >> initialize [
+	super initialize.
+	subFlags := TestBitmask new.
+]
+
+{ #category : #accessing }
+SubPerson >> subFlags [
+	^subFlags.
 ]

--- a/SSW ReStore Tests/SuperPerson.class.st
+++ b/SSW ReStore Tests/SuperPerson.class.st
@@ -7,46 +7,63 @@ Class {
 	#name : #SuperPerson,
 	#superclass : #Object,
 	#instVars : [
-		'surname',
-		'firstName'
+		'firstName',
+		'superFlags',
+		'surname'
 	],
 	#category : #'SSW ReStore Tests'
 }
 
-{ #category : #public }
-SuperPerson class >> reStoreDefinition [
-
-	^super reStoreDefinition
-		define: #surname as: (String maxSize: 255);
-		define: #firstName as: (String maxSize: 255);
-		yourself
+{ #category : #constants }
+SuperPerson class >> mutableAspects [
+	^#(#superFlags).
 ]
 
 { #category : #public }
+SuperPerson class >> reStoreDefinition [
+	^super reStoreDefinition
+		define: #surname as: (String maxSize: 255);
+		define: #firstName as: (String maxSize: 255);
+		define: #superFlags as: TestBitmask;
+		yourself.
+]
+
+{ #category : #accessing }
 SuperPerson >> firstName [
 
 	^firstName
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 SuperPerson >> firstName: a [
 
 	firstName := a
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 SuperPerson >> fullName [
 
 	^self firstName, ' ', self surname
 ]
 
-{ #category : #public }
+{ #category : #initialization }
+SuperPerson >> initialize [
+	super initialize.
+	superFlags := TestBitmask new.
+]
+
+{ #category : #accessing }
+SuperPerson >> superFlags [
+	^superFlags.
+]
+
+{ #category : #accessing }
 SuperPerson >> surname [
 
 	^surname
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 SuperPerson >> surname: a [
 
 	surname := a


### PR DESCRIPTION
Specifically occurs after fault-in through polymorphic reference whose declared class does not have that field.

Set the #_class: of the proxy *before* assigning the proxiedObject, so that #initializeCopyObject will operate on the full list of fields for the class of the object, even if the reference was declared using a superclass.

Also raise an error if the retrieved class does not #includesBehavior: the declared/expected class (e.g. accidentally requesting deferredObjectOfClass: SubPerson withID: <aMidPersonID>).