### PR TITLE
Polymorphic optimization

### DIFF
--- a/SSW ReStore Tables/Object.extension.st
+++ b/SSW ReStore Tables/Object.extension.st
@@ -69,6 +69,16 @@ Object class >> persistencyRootClass [
 ]
 
 { #category : '*SSW ReStore Tables' }
+Object >> related [
+
+	"Return a related version of the receiver"
+
+	^SSWDBRelatedWrapper on: self
+
+
+]
+
+{ #category : '*SSW ReStore Tables' }
 Object class >> reStoreDefinition [
 
 	"Return anSSWDBClassDefinition setting out the details of how the receiver is to be persisted.
@@ -148,16 +158,6 @@ Object class >> reStoreValueClass [
 	^self isPersistentBaseClass
 		ifTrue: [self] "Usually"
 		ifFalse: [self reStoreIDClass]
-]
-
-{ #category : '*SSW ReStore Tables' }
-Object >> related [
-
-	"Return a related version of the receiver"
-
-	^SSWDBRelatedWrapper on: self
-
-
 ]
 
 { #category : '*SSW ReStore Tables' }

--- a/SSW ReStore Tables/SSWAccessor.class.st
+++ b/SSW ReStore Tables/SSWAccessor.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWAccessor',
 	#superclass : 'Object',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'initializing' }

--- a/SSW ReStore Tables/SSWDBAbstractSubTable.class.st
+++ b/SSW ReStore Tables/SSWDBAbstractSubTable.class.st
@@ -10,8 +10,7 @@ Class {
 		'rootClass',
 		'classCondition'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBClassAccessor.class.st
+++ b/SSW ReStore Tables/SSWDBClassAccessor.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBClassAccessor',
 	#superclass : 'SSWDBPrivateAccessor',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'constants' }

--- a/SSW ReStore Tables/SSWDBClassDefinition.class.st
+++ b/SSW ReStore Tables/SSWDBClassDefinition.class.st
@@ -13,8 +13,7 @@ Class {
 		'idInstVar',
 		'namespace'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBControlField.class.st
+++ b/SSW ReStore Tables/SSWDBControlField.class.st
@@ -1,8 +1,7 @@
 Class {
 	#name : 'SSWDBControlField',
 	#superclass : 'SSWDBStaticField',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'actions' }

--- a/SSW ReStore Tables/SSWDBDataField.class.st
+++ b/SSW ReStore Tables/SSWDBDataField.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'SSWDBDataField',
 	#superclass : 'SSWDBStaticField',
+	#instVars : [
+		'isPolymorphic'
+	],
 	#category : 'SSW ReStore Tables'
 }
 
@@ -10,6 +13,27 @@ SSWDBDataField >> equivalentIn: anSSWDBTable [
 	"For data fields ask the table to look for an equivalent"
 
 	^(super equivalentIn: anSSWDBTable) ifNotNil: [ :field | anSSWDBTable equivalentDataFieldTo: field]
+]
+
+{ #category : 'initialize/release' }
+SSWDBDataField >> initialize [
+
+	super initialize.
+	isPolymorphic := false
+]
+
+{ #category : 'accessing' }
+SSWDBDataField >> isPolymorphic [
+	"Answer whether the receiver is polymorphic, that is,
+	another table in the hierarchy has a differently-defined field of the same name."
+
+	^ isPolymorphic
+]
+
+{ #category : 'accessing' }
+SSWDBDataField >> isPolymorphic: anObject [
+
+	isPolymorphic := anObject
 ]
 
 { #category : 'actions' }

--- a/SSW ReStore Tables/SSWDBDataField.class.st
+++ b/SSW ReStore Tables/SSWDBDataField.class.st
@@ -1,8 +1,7 @@
 Class {
 	#name : 'SSWDBDataField',
 	#superclass : 'SSWDBStaticField',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'accessing' }

--- a/SSW ReStore Tables/SSWDBDependentWrapper.class.st
+++ b/SSW ReStore Tables/SSWDBDependentWrapper.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBDependentWrapper',
 	#superclass : 'SSWDBRelatedWrapper',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'defining' }

--- a/SSW ReStore Tables/SSWDBDirectlyPersistedObject.class.st
+++ b/SSW ReStore Tables/SSWDBDirectlyPersistedObject.class.st
@@ -1,8 +1,7 @@
 Class {
 	#name : 'SSWDBDirectlyPersistedObject',
 	#superclass : 'Object',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBField.class.st
+++ b/SSW ReStore Tables/SSWDBField.class.st
@@ -12,8 +12,7 @@ Class {
 		'isRelated',
 		'columnIndex'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'comparing' }
@@ -85,13 +84,12 @@ SSWDBField >> columnIndex: anInteger [
 
 { #category : 'accessing' }
 SSWDBField >> equivalentIn: anSSWDBTable [
-
 	"Answer the equivalent field to the receiver in anSSWDBTable.
 	By default assume no equivalents, so if the receiver's table matches anSSWDBTable then it is the 'equivalent' "
 
-	^(self table == anSSWDBTable or: [self table = anSSWDBTable])
-		ifTrue: [self]
-		ifFalse: [nil]
+	^ self table = anSSWDBTable
+		  ifTrue: [ self ]
+		  ifFalse: [ nil ]
 ]
 
 { #category : 'accessing' }

--- a/SSW ReStore Tables/SSWDBFunctionField.class.st
+++ b/SSW ReStore Tables/SSWDBFunctionField.class.st
@@ -10,8 +10,7 @@ Class {
 		'function',
 		'arguments'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'testing' }

--- a/SSW ReStore Tables/SSWDBIDAccessor.class.st
+++ b/SSW ReStore Tables/SSWDBIDAccessor.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBIDAccessor',
 	#superclass : 'SSWDBPrivateAccessor',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'constants' }

--- a/SSW ReStore Tables/SSWDBIDField.class.st
+++ b/SSW ReStore Tables/SSWDBIDField.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'dataField'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'initialize/release' }

--- a/SSW ReStore Tables/SSWDBInheritedTable.class.st
+++ b/SSW ReStore Tables/SSWDBInheritedTable.class.st
@@ -36,13 +36,13 @@ SSWDBInheritedTable >> classField: anSSWDBField [
 { #category : 'accessing' }
 SSWDBInheritedTable >> equivalentDataFieldTo: aDBField [
 
-	"If aDBField came from a different inherited table,
+	"If aDBField has multiple definitions in the hierarchy,
+	and came from a different inherited table,
 	look for the equivalent (same-named) field in this table"
 
-	^aDBField table == self
-		ifTrue: [aDBField]
-		ifFalse: [self dataFields detect: [ :each | each name = aDBField name] ifNone: [nil]]
-
+	^(aDBField isPolymorphic and: [aDBField table ~~ self])
+		ifTrue: [self dataFields detect: [ :each | each name = aDBField name] ifNone: [nil]]
+		ifFalse: [aDBField]
 ]
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBInheritedTable.class.st
+++ b/SSW ReStore Tables/SSWDBInheritedTable.class.st
@@ -9,8 +9,7 @@ Class {
 	#instVars : [
 		'classField'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'accessing' }
@@ -37,22 +36,13 @@ SSWDBInheritedTable >> classField: anSSWDBField [
 { #category : 'accessing' }
 SSWDBInheritedTable >> equivalentDataFieldTo: aDBField [
 
-	"Look for the equivalent (same-named) field as aDBField in this table"
+	"If aDBField came from a different inherited table,
+	look for the equivalent (same-named) field in this table"
 
-	^aDBField name = self classField name 
+	^aDBField table == self
 		ifTrue: [aDBField]
 		ifFalse: [self dataFields detect: [ :each | each name = aDBField name] ifNone: [nil]]
-]
 
-{ #category : 'defining' }
-SSWDBInheritedTable >> initializeClassField: aDBField [
-	
-	^aDBField
-		table: self;
-		accessor: SSWDBClassAccessor new;
-		name: (self sqlDialect transformInstVarName: aDBField accessor nameInDB);
-		targetClass: Metaclass;
-		yourself
 ]
 
 { #category : 'instance creation' }
@@ -92,8 +82,14 @@ SSWDBInheritedTable >> recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy [
 { #category : 'defining' }
 SSWDBInheritedTable >> setDefaultClassField [
 
-	self classField: (self initializeClassField: SSWDBNonParameterizedControlField new).
-	self controlFields add: (self initializeClassField: SSWDBDataField new)
+	self classField: (SSWDBNonParameterizedControlField new
+			 table: self;
+			 accessor: SSWDBClassAccessor new;
+			 targetClass: Metaclass;
+			 yourself).
+	self classField name: (self sqlDialect transformInstVarName:
+			 self classField accessor nameInDB).
+	self controlFields add: self classField
 ]
 
 { #category : 'evaluating' }

--- a/SSW ReStore Tables/SSWDBInlinedClass.class.st
+++ b/SSW ReStore Tables/SSWDBInlinedClass.class.st
@@ -10,8 +10,7 @@ Class {
 	#instVars : [
 		'inlinedClass'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'defining' }

--- a/SSW ReStore Tables/SSWDBInstVarDefinition.class.st
+++ b/SSW ReStore Tables/SSWDBInstVarDefinition.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'name'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBInstVarWithFieldName.class.st
+++ b/SSW ReStore Tables/SSWDBInstVarWithFieldName.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'fieldName'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'accessing' }

--- a/SSW ReStore Tables/SSWDBIntermediateTable.class.st
+++ b/SSW ReStore Tables/SSWDBIntermediateTable.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBIntermediateTable',
 	#superclass : 'SSWDBAbstractSubTable',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'evaluating' }

--- a/SSW ReStore Tables/SSWDBNonParameterizedControlField.class.st
+++ b/SSW ReStore Tables/SSWDBNonParameterizedControlField.class.st
@@ -5,9 +5,8 @@ https://github.com/rko281/ReStore
 "
 Class {
 	#name : 'SSWDBNonParameterizedControlField',
-	#superclass : 'SSWDBStaticField',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#superclass : 'SSWDBControlField',
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'testing' }

--- a/SSW ReStore Tables/SSWDBPrivateAccessor.class.st
+++ b/SSW ReStore Tables/SSWDBPrivateAccessor.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBPrivateAccessor',
 	#superclass : 'SSWAccessor',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'initializing' }

--- a/SSW ReStore Tables/SSWDBQueryField.class.st
+++ b/SSW ReStore Tables/SSWDBQueryField.class.st
@@ -10,8 +10,7 @@ Class {
 		'field',
 		'columnIndex'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'evaluating' }

--- a/SSW ReStore Tables/SSWDBQueryTable.class.st
+++ b/SSW ReStore Tables/SSWDBQueryTable.class.st
@@ -11,8 +11,7 @@ Class {
 		'repetitionIndex',
 		'allFields'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBQueryTableField.class.st
+++ b/SSW ReStore Tables/SSWDBQueryTableField.class.st
@@ -10,8 +10,7 @@ Class {
 		'table',
 		'accessorPath'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBRelatedWrapper.class.st
+++ b/SSW ReStore Tables/SSWDBRelatedWrapper.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBRelatedWrapper',
 	#superclass : 'SSWDBWrapper',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'defining' }

--- a/SSW ReStore Tables/SSWDBRenamedInstVar.class.st
+++ b/SSW ReStore Tables/SSWDBRenamedInstVar.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'previousName'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'accessing' }

--- a/SSW ReStore Tables/SSWDBStaticField.class.st
+++ b/SSW ReStore Tables/SSWDBStaticField.class.st
@@ -9,8 +9,7 @@ Class {
 	#instVars : [
 		'targetClass'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'actions' }

--- a/SSW ReStore Tables/SSWDBSubTable.class.st
+++ b/SSW ReStore Tables/SSWDBSubTable.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBSubTable',
 	#superclass : 'SSWDBAbstractSubTable',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'evaluating' }

--- a/SSW ReStore Tables/SSWDBSuperTable.class.st
+++ b/SSW ReStore Tables/SSWDBSuperTable.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBSuperTable',
 	#superclass : 'SSWDBInheritedTable',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'evaluating' }

--- a/SSW ReStore Tables/SSWDBSuperTable.class.st
+++ b/SSW ReStore Tables/SSWDBSuperTable.class.st
@@ -32,8 +32,11 @@ SSWDBSuperTable >> forCreation [
 		tableForCreation instanceClass: cls.
 		table dataFields do: 
 			[ :field | 
-			(tableForCreation hasFieldAccessing: field accessor name) ifFalse: 
-				[tableForCreation dataFields add: field]].
+			(tableForCreation fieldAccessing: field accessor name)
+				ifNil: [tableForCreation dataFields add: field]
+				ifNotNil: [:existing |
+					field isPolymorphic: true.
+					existing isPolymorphic: true]].
 		table collectionSpecs do:
 			[ :spec |
 			(tableForCreation hasCollectionAccessing: spec accessor name) ifFalse: 

--- a/SSW ReStore Tables/SSWDBTable.class.st
+++ b/SSW ReStore Tables/SSWDBTable.class.st
@@ -22,8 +22,7 @@ Class {
 		'readAllBatchSize',
 		'namespace'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBTableComponent.class.st
+++ b/SSW ReStore Tables/SSWDBTableComponent.class.st
@@ -10,8 +10,7 @@ Class {
 		'accessor',
 		'readAllStatement'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWDBUnrelatedWrapper.class.st
+++ b/SSW ReStore Tables/SSWDBUnrelatedWrapper.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBUnrelatedWrapper',
 	#superclass : 'SSWDBWrapper',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'defining' }

--- a/SSW ReStore Tables/SSWDBVersionAccessor.class.st
+++ b/SSW ReStore Tables/SSWDBVersionAccessor.class.st
@@ -6,8 +6,7 @@ https://github.com/rko281/ReStore
 Class {
 	#name : 'SSWDBVersionAccessor',
 	#superclass : 'SSWDBPrivateAccessor',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'constants' }

--- a/SSW ReStore Tables/SSWFieldInliner.class.st
+++ b/SSW ReStore Tables/SSWFieldInliner.class.st
@@ -15,8 +15,7 @@ Class {
 		'inlinedClass',
 		'fields'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWInlinedInstVarAccessor.class.st
+++ b/SSW ReStore Tables/SSWInlinedInstVarAccessor.class.st
@@ -11,8 +11,7 @@ Class {
 		'inlinedAccessor',
 		'inlinedClass'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'testing' }

--- a/SSW ReStore Tables/SSWInstVarAccessor.class.st
+++ b/SSW ReStore Tables/SSWInstVarAccessor.class.st
@@ -11,8 +11,7 @@ Class {
 		'slot',
 		'name'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }

--- a/SSW ReStore Tables/SSWMutableInstVarAccessor.class.st
+++ b/SSW ReStore Tables/SSWMutableInstVarAccessor.class.st
@@ -1,8 +1,7 @@
 Class {
 	#name : 'SSWMutableInstVarAccessor',
 	#superclass : 'SSWInstVarAccessor',
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'evaluating' }

--- a/SSW ReStore Tables/SSWTransformingInstVarAccessor.class.st
+++ b/SSW ReStore Tables/SSWTransformingInstVarAccessor.class.st
@@ -9,8 +9,7 @@ Class {
 	#instVars : [
 		'transformation'
 	],
-	#category : 'SSW ReStore Tables',
-	#package : 'SSW ReStore Tables'
+	#category : 'SSW ReStore Tables'
 }
 
 { #category : 'instance creation' }


### PR DESCRIPTION
SSWDBField>>= already checks #==, so #equivalentIn: doesn't need to do so separately.

But, we _can_ check #== in order to not re-lookup fields that are already correct.

Make the class field a true control field, so we don't have to special-case exclude it from equivalency matching.  Move SSWDBNonParameterizedControlField under regular ControlField, so it inherits #populateObject:with:.

I tried the idea of marking fields as polymorphic--having multiple definitions in the same table hierarchy--when creating the merged table, so we can only re-lookup fields where this is set. But it seems that `#forCreation` is the wrong place to do this, as the changes are not actually made to the tables that stick around in memory. Feel free to just discard if it's hard to make this approach work.

I don't believe the polymorphic flag is necessary for collections, even though they could be redefined, because they are not fetched as part of the same query as the object itself, so will always be fetched once the true class of the object is known and the correct table can be used. If this ever changes it would need to be included there as well.